### PR TITLE
Test and clean up the client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,33 @@
 language: python
-python:
-  - "2.7"
 
-# command to install dependencies
-install:
-  - "pip install -e .[test]"
-  - "pip install coveralls"
-  - "pip freeze"
+# align the env's and the python's; below "$PY27 ||" will not be run on py26,
+# and "$PY27 &&" will only be run on py26.
+matrix:
+  include:
+    - python: "2.6"
+      env: PY27=false
+    - python: "2.7"
+      env: PY27=true
+
+
+# install dependencies.  The blueprint won't even install on Py26, so don't try
+install: |
+    if $PY27; then
+        pip install -e .[test]
+        pip install coveralls
+    else
+        pip install mock nosetests
+    fi;
+    pip freeze
 
 # run everything in a single script, so we get a nice summary at the end
-script:
-  - bash ./validate.sh
+script: |
+    if $PY27; then
+        bash ./validate.sh
+    else
+        nosetests test_tooltool.py
+    fi
 
 after_success:
-  - coveralls --rcfile coveragerc
+  # only get coverage on python-2.7
+  - $PY27 && coveralls --rcfile coveragerc

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -394,7 +394,7 @@ def call_main(*args):
         try:
             return tooltool.main(list(args), _skip_logging=True)
         except SystemExit, e:
-            return "exit {}".format(e.code)
+            return "exit %d" % e.code
     finally:
         sys.stderr = old_stderr
 
@@ -509,7 +509,7 @@ class FetchTests(unittest.TestCase):
 
     def add_file_to_dir(self, file, corrupt=False):
         content = 'X' * len(file) if corrupt else file
-        open(os.path.join(self.test_dir, "file-{}".format(file)), "w").write(content)
+        open(os.path.join(self.test_dir, "file-" + file), "w").write(content)
 
     def add_file_to_cache(self, file, corrupt=False):
         if not os.path.exists(self.cache_dir):
@@ -523,7 +523,7 @@ class FetchTests(unittest.TestCase):
         manifest = []
         for file in files:
             manifest.append({
-                'filename': 'file-{}'.format(file),
+                'filename': 'file-' + file,
                 'size': len(file),
                 'algorithm': 'sha512',
                 'digest': hashlib.sha512(file).hexdigest(),
@@ -768,7 +768,7 @@ class FetchFileTests(BaseFileRecordTest):
     def test_fetch_file(self):
         with mock.patch('tooltool._urlopen') as _urlopen:
             # the first URL doesn't match, so this loops twice
-            self.fake_urlopen(_urlopen, {'http://b/sha512/{}'.format(self.sample_hash): 'abcd'})
+            self.fake_urlopen(_urlopen, {'http://b/sha512/' + self.sample_hash: 'abcd'})
             filename = tooltool.fetch_file(['http://a', 'http://b'], self.test_record)
             assert filename
             eq_(open(filename).read(), 'abcd')
@@ -778,7 +778,7 @@ class FetchFileTests(BaseFileRecordTest):
         with mock.patch('tooltool._urlopen') as _urlopen:
             # the first URL doesn't match, so this loops twice
             self.fake_urlopen(
-                _urlopen, {'http://b/sha512/{}'.format(self.sample_hash): 'abcd'}, exp_size=1024)
+                _urlopen, {'http://b/sha512/' + self.sample_hash: 'abcd'}, exp_size=1024)
             filename = tooltool.fetch_file(
                 ['http://a', 'http://b'], self.test_record, grabchunk=1024)
             assert filename
@@ -788,7 +788,7 @@ class FetchFileTests(BaseFileRecordTest):
     def test_fetch_file_auth_file(self):
         with mock.patch('tooltool._urlopen') as _urlopen:
             # the first URL doesn't match, so this loops twice
-            self.fake_urlopen(_urlopen, {'http://b/sha512/{}'.format(self.sample_hash): 'abcd'},
+            self.fake_urlopen(_urlopen, {'http://b/sha512/' + self.sample_hash: 'abcd'},
                               exp_auth_file='auth')
             filename = tooltool.fetch_file(
                 ['http://a', 'http://b'], self.test_record, auth_file='auth')

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -339,6 +339,10 @@ def test_main_bad_command():
     eq_(call_main('tooltool', 'foo'), 1)
 
 
+def test_main_bad_algorithm():
+    eq_(call_main('tooltool', '--algorithm', 'sha13', 'fetch'), 'exit 2')
+
+
 def test_command_list():
     with mock.patch('tooltool.list_manifest') as list_manifest:
         eq_(call_main('tooltool', 'list', '--manifest', 'foo.tt'), 0)

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -4,12 +4,12 @@
 
 import copy
 import json
+import mock
 import os
 import shutil
 import tempfile
-import unittest
-
 import tooltool
+import unittest
 
 
 class DigestTests(unittest.TestCase):
@@ -310,3 +310,12 @@ class TestManifestOperations(BaseFileRecordTest):
     def tearDown(self):
         os.chdir(self.startingwd)
         shutil.rmtree(self.test_dir)
+
+
+def test_main_help():
+    try:
+        tooltool.main(['tooltool', '--help'], _skip_logging=True)
+    except SystemExit:
+        pass
+    else:
+        assert 0, "didn't exit"

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -359,6 +359,14 @@ class TestManifestOperations(BaseFileRecordTest):
                           tooltool.open_manifest('no-such-file'))
 
 
+def test_execute():
+    assert tooltool.execute('echo foo; echo bar')
+
+
+def test_execute_fails():
+    assert not tooltool.execute('false')
+
+
 def call_main(*args):
     try:
         old_stderr = sys.stderr

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -715,6 +715,10 @@ class FetchTests(unittest.TestCase):
         self.setup_tarball('tar -cjf basename.tar.bz2 basename')
         self.try_untar_file('basename.tar.bz2')
 
+    def test_untar_file_invalid_xz(self):
+        self.setup_tarball('echo BOGUS > basename.tar.xz')
+        self.assertFalse(tooltool.untar_file('basename.tar.xz'))
+
     def test_untar_file_not_tarfile(self):
         open('basename.tar.shrink', 'w').write('not a tarfile')
         self.assertFalse(tooltool.untar_file('basename.tar.shrink'))

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -784,6 +784,26 @@ class FetchFileTests(BaseFileRecordTest):
             assert filename is None
 
 
+def test_urlopen_no_auth_file():
+    with mock.patch("urllib2.urlopen") as urlopen:
+        tooltool._urlopen("url")
+        urlopen.assert_called_with("url")
+
+
+def test_touch():
+    open("testfile", "w")
+    os.utime("testfile", (0, 0))
+    tooltool.touch("testfile")
+    assert os.stat("testfile").st_mtime > 0
+    os.unlink("testfile")
+
+
+def test_touch_doesnt_exit():
+    assert not os.path.exists("testfile")
+    tooltool.touch("testfile")
+    assert not os.path.exists("testfile")
+
+
 class PurgeTests(unittest.TestCase):
 
     def setUp(self):

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -474,8 +474,8 @@ def test_command_package():
 class FetchTests(unittest.TestCase):
 
     _server_files = ['one', 'two', 'three']
-    server_files_by_hash = {hashlib.sha512(v).hexdigest(): v
-                            for v in _server_files}
+    server_files_by_hash = dict((hashlib.sha512(v).hexdigest(), v)
+                                for v in _server_files)
     server_corrupt = False
     urls = ['http://a', 'http://2']
 

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -25,9 +25,6 @@ class DigestTests(unittest.TestCase):
         # of Linus Torvalds explaining how he pronounces 'Linux'
         self.assertEqual(test_digest, self.sample_digest)
 
-# Ugh, I've managed to have a few different test naming schemes already :(
-# TODO: clean this up!
-
 
 class BaseFileRecordTest(unittest.TestCase):
 
@@ -129,8 +126,7 @@ class TestFileRecord(BaseFileRecordTest):
     def test_repr(self):
         a = eval(repr(self.test_record))
         self.assertEqual(str(a), str(self.test_record))
-        # TODO: Figure out why things aren't working here
-        #self.assertEqual(a, self.test_record)
+        self.assertEqual(a, self.test_record)
 
     def test_create_file_record(self):
         fr = tooltool.create_file_record(self.sample_file, self.sample_algo)

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -245,6 +245,15 @@ class TestFileRecordJSONCodecs(BaseFileRecordListTest):
         for i in ['filename', 'size', 'algorithm', 'digest']:
             self.assertEqual(dict_from_json[i], self.test_record.__dict__[i])
 
+    def test_json_dumps_with_unpack(self):
+        self.test_record.unpack = True
+        json_string = json.dumps(
+            self.test_record, cls=tooltool.FileRecordJSONEncoder)
+        from_json = json.loads(json_string,
+                cls=tooltool.FileRecordJSONDecoder)
+        for i in ['filename', 'size', 'algorithm', 'digest', 'unpack']:
+            self.assertEqual(getattr(from_json, i), getattr(self.test_record, i), i)
+
     def test_decode_list(self):
         json_string = json.dumps(
             self.record_list, cls=tooltool.FileRecordJSONEncoder)

--- a/tooltool.py
+++ b/tooltool.py
@@ -850,7 +850,6 @@ def distribute(folder, message, user, host, path, algorithm):  # pragma: no cove
     return upload(package(folder, algorithm, message), user, host, path)
 
 
-# TODO: write tests for this function
 def process_command(options, args):
     """ I know how to take a list of program arguments and
     start doing the right thing with them"""

--- a/tooltool.py
+++ b/tooltool.py
@@ -167,12 +167,15 @@ class FileRecordJSONEncoder(json.JSONEncoder):
             log.warn(err)
             raise FileRecordJSONEncoderException(err)
         else:
-            return {
+            rv = {
                 'filename': obj.filename,
                 'size': obj.size,
                 'algorithm': obj.algorithm,
                 'digest': obj.digest,
             }
+            if obj.unpack:
+                rv['unpack'] = True
+            return rv
 
     def default(self, f):
         if issubclass(type(f), list):

--- a/tooltool.py
+++ b/tooltool.py
@@ -103,7 +103,7 @@ class FileRecord(object):
         return repr(self)
 
     def __repr__(self):
-        return "%s.%s(filename='%s', size='%s', digest='%s', algorithm='%s')" % (
+        return "%s.%s(filename='%s', size=%s, digest='%s', algorithm='%s')" % (
             __name__,
             self.__class__.__name__,
             self.filename,

--- a/tooltool.py
+++ b/tooltool.py
@@ -318,6 +318,17 @@ def digest_file(f, a):
     return h.hexdigest()
 
 
+def execute(cmd):
+    """Execute CMD, logging its stdout at the info level"""
+    process = Popen(cmd, shell=True, stdout=PIPE)
+    while True:
+        line = process.stdout.readline()
+        if not line:
+            break
+        log.info(line.replace('\n', ''))
+    return process.wait() == 0
+
+
 def open_manifest(manifest_file):
     """I know how to take a filename and load it into a Manifest object"""
     if os.path.exists(manifest_file):
@@ -530,7 +541,8 @@ def untar_file(filename):
         if os.path.exists(base_file):
             log.info('rm tree: %s' % base_file)
             shutil.rmtree(base_file)
-        execute('tar -Jxf %s' % filename)
+        if not execute('tar -Jxf %s' % filename):
+            return False
     else:
         log.error("Unknown zip extension for filename '%s'" % filename)
         return False
@@ -767,16 +779,6 @@ def package(folder, algorithm, message):  # pragma: no cover
              (os.path.join(os.path.join(dirname, package_name)), folder))
 
     return os.path.join(os.path.join(dirname, package_name))
-
-
-# TODO: test
-def execute(cmd):
-    process = Popen(cmd, shell=True, stdout=PIPE)
-    while True:
-        line = process.stdout.readline()
-        if not line:
-            break
-        log.info(line.replace('\n', ''))
 
 
 def upload(package, user, host, path):  # pragma: no cover

--- a/tooltool.py
+++ b/tooltool.py
@@ -387,7 +387,6 @@ def validate_manifest(manifest_file):
         return False
 
 
-# TODO: write tests for this function
 def add_files(manifest_file, algorithm, filenames, create_package=False):
     # returns True if all files successfully added, False if not
     # and doesn't catch library Exceptions.  If any files are already
@@ -405,7 +404,8 @@ def add_files(manifest_file, algorithm, filenames, create_package=False):
         log.debug("adding %s" % filename)
         path, name = os.path.split(filename)
         new_fr = create_file_record(filename, algorithm)
-        if create_package:
+        if create_package:  # pragma: no cover
+            # this is going to go away with the `package` action
             shutil.copy(filename,
                         os.path.join(os.path.split(manifest_file)[0], new_fr.digest))
             log.debug("Added file %s to tooltool package %s with hash %s" % (
@@ -415,15 +415,11 @@ def add_files(manifest_file, algorithm, filenames, create_package=False):
         for fr in old_manifest.file_records:
             log.debug("manifest file has '%s'" % "', ".join(
                 [x.filename for x in old_manifest.file_records]))
-            if new_fr == fr and new_fr.validate():
-                # TODO: Decide if this case should really cause a False return
-                log.info("file already in old_manifest file and matches")
+            if new_fr == fr:
+                log.info("file already in old_manifest")
                 add = False
-            elif new_fr == fr and not new_fr.validate():
-                log.error("file already in old_manifest file but is invalid")
-                add = False
-            if filename == fr.filename:
-                log.error("manifest already contains file named %s" % filename)
+            elif filename == fr.filename:
+                log.error("manifest already contains a different file named %s" % filename)
                 add = False
         if add:
             new_manifest.file_records.append(new_fr)

--- a/tooltool.py
+++ b/tooltool.py
@@ -966,4 +966,4 @@ def main(argv, _skip_logging=False):
     return 0 if process_command(options, args) else 1
 
 if __name__ == "__main__":  # pragma: no cover
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv))

--- a/tooltool.py
+++ b/tooltool.py
@@ -450,7 +450,9 @@ def touch(f):
 
 
 def _urlopen(url, auth_file=None):
-    if auth_file:
+    if auth_file:  # pragma: no cover
+        # this is particularly hard to mock, and will change completely with
+        # the new tooltool anyway.
         with open(auth_file, 'r') as fHandle:
             data = fHandle.read()
         data = data.split('\n')

--- a/tooltool.py
+++ b/tooltool.py
@@ -320,6 +320,7 @@ def digest_file(f, a):
 
 def execute(cmd):
     """Execute CMD, logging its stdout at the info level"""
+    # TODO: capture stderr, too
     process = Popen(cmd, shell=True, stdout=PIPE)
     while True:
         line = process.stdout.readline()

--- a/tooltool.py
+++ b/tooltool.py
@@ -931,7 +931,7 @@ def main(argv, _skip_logging=False):
                       help='specify the manifest file to be operated on')
     parser.add_option('-d', '--algorithm', default='sha512',
                       dest='algorithm', action='store',
-                      help='openssl hashing algorithm to use')
+                      help='hashing algorithm to use (only sha512 is allowed)')
     parser.add_option('-o', '--overwrite', default=False,
                       dest='overwrite', action='store_true',
                       help='UNUSED; present for backward compatibility')
@@ -967,7 +967,7 @@ def main(argv, _skip_logging=False):
     parser.add_option('--authentication-file',
                       help='Use http authentication to download a file.', dest='auth_file')
 
-    (options_obj, args) = parser.parse_args(argv)
+    (options_obj, args) = parser.parse_args(argv[1:])
     # Dictionaries are easier to work with
     options = vars(options_obj)
 
@@ -982,6 +982,7 @@ def main(argv, _skip_logging=False):
 
     if len(args) < 1:
         parser.error('You must specify a command')
+
     return 0 if process_command(options, args) else 1
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tooltool.py
+++ b/tooltool.py
@@ -246,9 +246,7 @@ class Manifest(object):
         # sort the file records by filename before comparing
         mine = sorted((fr.filename, fr) for fr in self.file_records)
         theirs = sorted((fr.filename, fr) for fr in other.file_records)
-        if mine != theirs:
-            return False
-        return True
+        return mine == theirs
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -328,7 +326,7 @@ def execute(cmd):
         line = process.stdout.readline()
         if not line:
             break
-        log.info(line.replace('\n', ''))
+        log.info(line.replace('\n', ' '))
     return process.wait() == 0
 
 

--- a/tooltool.py
+++ b/tooltool.py
@@ -542,8 +542,6 @@ def untar_file(filename):
         return False
     return True
 
-# TODO: write tests for this function
-
 
 def fetch_files(manifest_file, base_urls, filenames=[], cache_folder=None, auth_file=None):
     # Lets load the manifest file
@@ -665,6 +663,7 @@ def fetch_files(manifest_file, base_urls, filenames=[], cache_folder=None, auth_
         else:
             failed_files.append(localfile.filename)
             log.error("'%s'" % filerecord_for_validation.describe())
+            os.remove(temp_file_name)
 
     # Unpack files that need to be unpacked.
     for filename in unpack_files:

--- a/tooltool.py
+++ b/tooltool.py
@@ -320,7 +320,6 @@ def digest_file(f, a):
 
 def execute(cmd):
     """Execute CMD, logging its stdout at the info level"""
-    # TODO: capture stderr, too
     process = Popen(cmd, shell=True, stdout=PIPE)
     while True:
         line = process.stdout.readline()
@@ -537,7 +536,7 @@ def untar_file(filename):
         if os.path.exists(base_file):
             log.info('rm tree: %s' % base_file)
             shutil.rmtree(base_file)
-        if not execute('tar -Jxf %s' % filename):
+        if not execute('tar -Jxf %s 2>&1' % filename):
             return False
     else:
         log.error("Unknown zip extension for filename '%s'" % filename)

--- a/tooltool.py
+++ b/tooltool.py
@@ -739,7 +739,7 @@ def remove_trailing_slashes(folder):
     return re.sub("/*$", "", folder)
 
 
-def package(folder, algorithm, message):
+def package(folder, algorithm, message):  # pragma: no cover
     if not os.path.exists(folder) or not os.path.isdir(folder):
         msg = 'Folder %s does not exist!' % folder
         log.error(msg)
@@ -789,7 +789,7 @@ def package(folder, algorithm, message):
     return os.path.join(os.path.join(dirname, package_name))
 
 
-def execute(cmd):
+def execute(cmd):  # pragma: no cover
     process = Popen(cmd, shell=True, stdout=PIPE)
     while True:
         line = process.stdout.readline()
@@ -798,7 +798,7 @@ def execute(cmd):
         log.info(line.replace('\n', ''))
 
 
-def upload(package, user, host, path):
+def upload(package, user, host, path):  # pragma: no cover
     # TODO s: validate package
     package = remove_trailing_slashes(package)
 
@@ -846,7 +846,7 @@ def upload(package, user, host, path):
     return True
 
 
-def distribute(folder, message, user, host, path, algorithm):
+def distribute(folder, message, user, host, path, algorithm):  # pragma: no cover
     return upload(package(folder, algorithm, message), user, host, path)
 
 
@@ -883,14 +883,14 @@ def process_command(options, args):
             cmd_args,
             cache_folder=options['cache_folder'],
             auth_file=options.get("auth_file"))
-    elif cmd == 'package':
+    elif cmd == 'package':  # pragma: no cover
         if not options.get('folder') or not options.get('message'):
             log.critical('package command requires a folder to be specified, containing the '
                          'files to be added to the tooltool package, and a message providing info '
                          'about the package')
             return False
         return package(options['folder'], options['algorithm'], options['message'])
-    elif cmd == 'upload':
+    elif cmd == 'upload':  # pragma: no cover
         if not options.get('package') or not options.get('user') or \
            not options.get('host') or not options.get('path'):
             log.critical('upload command requires the package folder to be uploaded, and the '
@@ -901,7 +901,7 @@ def process_command(options, args):
             options.get('user'),
             options.get('host'),
             options.get('path'))
-    elif cmd == 'distribute':
+    elif cmd == 'distribute':  # pragma: no cover
         if not options.get('folder') or not options.get('message') or not options.get('user') or \
            not options.get('host') or not options.get('path'):
             log.critical('distribute command requires the following parameters: --folder, '

--- a/tooltool.py
+++ b/tooltool.py
@@ -465,8 +465,6 @@ def _urlopen(url, auth_file=None):
 
     return urllib2.urlopen(url)
 
-# TODO: write tests for this function
-
 
 def fetch_file(base_urls, file_record, grabchunk=1024 * 4, auth_file=None):
     # A file which is requested to be fetched that exists locally will be
@@ -505,8 +503,8 @@ def fetch_file(base_urls, file_record, grabchunk=1024 * 4, auth_file=None):
             log.info("...failed to fetch '%s' from %s" %
                      (file_record.filename, base_url))
             log.debug("%s" % e)
-        except IOError:
-            log.info("failed to write to '%s'" %
+        except IOError:  # pragma: no cover
+            log.info("failed to write to temporary file for '%s'" %
                      file_record.filename, exc_info=True)
 
     # cleanup temp file in case of issues
@@ -515,7 +513,7 @@ def fetch_file(base_urls, file_record, grabchunk=1024 * 4, auth_file=None):
     else:
         try:
             os.remove(temp_path)
-        except OSError:
+        except OSError:  # pragma: no cover
             pass
         return None
 

--- a/tooltool.py
+++ b/tooltool.py
@@ -344,7 +344,6 @@ def open_manifest(manifest_file):
             "manifest file '%s' does not exist" % manifest_file)
 
 
-# TODO: write tests for this function
 def list_manifest(manifest_file):
     """I know how print all the files in a location"""
     try:

--- a/tooltool.py
+++ b/tooltool.py
@@ -980,6 +980,9 @@ def main(argv, _skip_logging=False):
         ch.setFormatter(cf)
         log.addHandler(ch)
 
+    if options['algorithm'] != 'sha512':
+        parser.error('only --algorithm sha512 is supported')
+
     if len(args) < 1:
         parser.error('You must specify a command')
 

--- a/validate.sh
+++ b/validate.sh
@@ -92,9 +92,6 @@ $modified && not_ok "some imports were re-ordered and changes will need to be co
 status "running shell tests"
 bash test.sh >/dev/null 2>&1 || not_ok "shell tests failed"
 
-status "running client tests"
-python test_tooltool.py >/dev/null 2>&1 || not_ok "client tests failed"
-
 status "building docs"
 relengapi build-docs --development || not_ok "build-docs failed"
 

--- a/validate.sh
+++ b/validate.sh
@@ -100,8 +100,7 @@ relengapi build-docs --development || not_ok "build-docs failed"
 
 status "running tests (under coverage)"
 coverage erase || not_ok "coverage failed"
-# NOTE: to add coverage of the client (currently terrible!), use --source=relengapi,tooltool
-coverage run --rcfile=coveragerc --source=relengapi $(which relengapi) run-tests || not_ok "tests failed"
+coverage run --rcfile=coveragerc --source=relengapi,tooltool $(which relengapi) run-tests || not_ok "tests failed"
 
 status "checking coverage"
 coverage report --rcfile=coveragerc --fail-under=${COVERAGE_MIN} >${tmpbase}/covreport || not_ok "less than ${COVERAGE_MIN}% coverage"


### PR DESCRIPTION
This gets tooltool.py to 100% coverage.

Well, sort of -- the bits that are both hard to test and destined for the bitbucket with the ongoing rewrite are tagged with 'pragma: no cover'.

This also includes a bunch of bug fixes and minor refactors in tooltool.py:

 * fail on any path info in filenames, regardless of platform
 * `repr` the size as an integer, not a string
 * fix manifest comparison to compare sorted manifests
 * don't try to sort manifests while manipulating them
 * don't attempt to re-validate files in `add_files`, as they may not be in the cwd and thus validation will fail
 * return false from `untar_file` if the xz untar operation fails
 * remove fetched temp files if they fail verification
 * simplify `purge`
 * refactor cli implementation to ease testing
 * indicate that only sha512 algorithm is supported