### PR TITLE
﻿Bug 1167636 - Add option for TTL

### DIFF
--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -519,7 +519,7 @@ def test_command_add_visibility_public():
 def test_command_add_ttl():
     with mock.patch('tooltool.add_files') as add_files:
         eq_(call_main('tooltool', 'add', '--ttl', '2', 'a', 'b'), 0)
-        add_files.assert_called_with('manifest.tt', 'sha512', ['a', 'b'], None, 2)
+        add_files.assert_called_with('manifest.tt', 'sha512', ['a', 'b'], None, 2*86400)
 
 
 def test_command_purge_no_folder():

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -483,7 +483,7 @@ def test_main_bad_algorithm():
 
 
 def test_main_bad_ttl():
-    eq_(call_main('tooltool', '--ttl', '0'), 'exit 2')
+    eq_(call_main('tooltool', '--ttl', '-3'), 'exit 2')
 
 
 def test_command_list():

--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -482,6 +482,10 @@ def test_main_bad_algorithm():
     eq_(call_main('tooltool', '--algorithm', 'sha13', 'fetch'), 'exit 2')
 
 
+def test_main_bad_ttl():
+    eq_(call_main('tooltool', '--ttl', '0'), 'exit 2')
+
+
 def test_command_list():
     with mock.patch('tooltool.list_manifest') as list_manifest:
         eq_(call_main('tooltool', 'list', '--manifest', 'foo.tt'), 0)
@@ -510,6 +514,12 @@ def test_command_add_visibility_public():
     with mock.patch('tooltool.add_files') as add_files:
         eq_(call_main('tooltool', 'add', '--visibility', 'public', 'a', 'b'), 0)
         add_files.assert_called_with('manifest.tt', 'sha512', ['a', 'b'], 'public', None)
+
+
+def test_command_add_ttl():
+    with mock.patch('tooltool.add_files') as add_files:
+        eq_(call_main('tooltool', 'add', '--ttl', '2', 'a', 'b'), 0)
+        add_files.assert_called_with('manifest.tt', 'sha512', ['a', 'b'], None, 2)
 
 
 def test_command_purge_no_folder():
@@ -1482,6 +1492,15 @@ class AddFiles(BaseManifestTest):
         file_json['visibility'] = 'public'
         assert tooltool.add_files('manifest.tt', 'sha512', [file_json['filename']], 'public', None)
         self.assert_manifest([self.test_record_json, file_json])
+
+    def test_append_ttl(self):
+        """Adding a new file to an existing manifest results in a manifest with
+        two files, with the ttl set on the new one"""
+        file_json = self.make_file()
+        file_json['ttl'] = 2
+        assert tooltool.add_files('manifest.tt', 'sha512', [file_json['filename']], None, 2)
+        self.assert_manifest([self.test_record_json, file_json])
+
 
     def test_new_manifest(self):
         """Adding a new file to a new manifest results in a manifest with one

--- a/tooltool.py
+++ b/tooltool.py
@@ -46,8 +46,6 @@ __version__ = '1'
 DEFAULT_MANIFEST_NAME = 'manifest.tt'
 TOOLTOOL_PACKAGE_SUFFIX = '.TOOLTOOL-PACKAGE'
 
-TTL_MAX_VALUE = 365
-
 
 log = logging.getLogger(__name__)
 
@@ -964,12 +962,14 @@ def main(argv, _skip_logging=False):
                       help='Visibility level of this file; "internal" is for '
                            'files that cannot be distributed out of the company '
                            'but not for secrets; "public" files are available to '
-                           'anyone withou trestriction')
+                           'anyone without restriction')
     parser.add_option('--ttl', default=None,
                       type='int', dest='ttl', action='store',
                       help='Time to live for the file to uploaded, in days; the '
                            'files will be removed from storage, but the metadata '
-                           'will be retained')
+                           'will be retained. Reuploading a file with a later TTL '
+                           'expiration date will override previous values. A value '
+                           'of 0, or otherwise blank, will let the file live forever.')
     parser.add_option('-o', '--overwrite', default=False,
                       dest='overwrite', action='store_true',
                       help='UNUSED; present for backward compatibility')
@@ -1022,8 +1022,8 @@ def main(argv, _skip_logging=False):
     if options['algorithm'] != 'sha512':
         parser.error('only --algorithm sha512 is supported')
 
-    if options['ttl'] is not None and not 0 < options['ttl'] <= TTL_MAX_VALUE:
-        parser.error('ttl values must be between 1 and %r days, inclusive' % TTL_MAX_VALUE)
+    if options['ttl'] is not None and options['ttl'] < 0:
+        parser.error('ttl values must be non-negative')
 
     if len(args) < 1:
         parser.error('You must specify a command')

--- a/tooltool.py
+++ b/tooltool.py
@@ -969,7 +969,7 @@ def main(argv, _skip_logging=False):
                            'files will be removed from storage, but the metadata '
                            'will be retained. Reuploading a file with a later TTL '
                            'expiration date will override previous values. A value '
-                           'of 0, or otherwise blank, will let the file live forever.')
+                           'of 0, or if the option is omitted, will let the file live forever.')
     parser.add_option('-o', '--overwrite', default=False,
                       dest='overwrite', action='store_true',
                       help='UNUSED; present for backward compatibility')
@@ -1024,6 +1024,10 @@ def main(argv, _skip_logging=False):
 
     if options['ttl'] is not None and options['ttl'] < 0:
         parser.error('ttl values must be non-negative')
+
+    # translate days into seconds
+    if options['ttl']:
+        options['ttl'] *= 86400
 
     if len(args) < 1:
         parser.error('You must specify a command')


### PR DESCRIPTION
This adds a --ttl option in the tooltool client, which will optionally add a ttl field to the manifest that is an integer in days. Valid values for the time to live are between 1 to 365 days, inclusive. I figure having the file expire any longer than that isn't all that useful, this would normally be used for smaller values (say one or two days). The field will default to a value of None, which will keep the file permanent. 

This option will need to be implemented in the tooltool server, and should otherwise be ignored.

[Link to referenced bug 1167636](https://bugzilla.mozilla.org/show_bug.cgi?id=1167636)