### PR TITLE
Add --unpack switch.

### DIFF
--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -1478,6 +1478,15 @@ class AddFiles(BaseManifestTest):
         assert tooltool.add_files('manifest.tt', 'sha512', [file_json['filename']], 'public')
         self.assert_manifest([self.test_record_json, file_json])
 
+    def test_append_unpack(self):
+        """Adding a new file to an existing manifest results in a manifest with
+        two files, with the visibility and unpack attributes set"""
+        file_json = self.make_file()
+        file_json['visibility'] = 'public'
+        file_json['unpack'] = true
+        assert tooltool.add_files('manifest.tt', 'sha512', file_json['filename'], 'public', true)
+        self.assert_manifest([self.test_record_json, file_json])
+
     def test_new_manifest(self):
         """Adding a new file to a new manifest results in a manifest with one
         file"""

--- a/tooltool.py
+++ b/tooltool.py
@@ -955,6 +955,10 @@ def main(argv, _skip_logging=False):
                            'files that cannot be distributed out of the company '
                            'but not for secrets; "public" files are available to '
                            'anyone withou trestriction')
+    parser.add_option('--unpack', default=False,
+                      dest='unpack', action='store_true',
+                      help='Request unpacking this file after fetch.'
+                           ' This is helpful with tarballs.')
     parser.add_option('-o', '--overwrite', default=False,
                       dest='overwrite', action='store_true',
                       help='UNUSED; present for backward compatibility')

--- a/tooltool.py
+++ b/tooltool.py
@@ -397,7 +397,7 @@ def validate_manifest(manifest_file):
         return False
 
 
-def add_files(manifest_file, algorithm, filenames, visibility):
+def add_files(manifest_file, algorithm, filenames, visibility, unpack):
     # returns True if all files successfully added, False if not
     # and doesn't catch library Exceptions.  If any files are already
     # tracked in the manifest, return will be False because they weren't
@@ -415,6 +415,7 @@ def add_files(manifest_file, algorithm, filenames, visibility):
         path, name = os.path.split(filename)
         new_fr = create_file_record(filename, algorithm)
         new_fr.visibility = visibility
+        new_fr.unpack = unpack
         log.debug("appending a new file record to manifest file")
         add = True
         for fr in old_manifest.file_records:
@@ -906,7 +907,7 @@ def process_command(options, args):
         return validate_manifest(options['manifest'])
     elif cmd == 'add':
         return add_files(options['manifest'], options['algorithm'], cmd_args,
-                         options['visibility'])
+                         options['visibility'], options['unpack'])
     elif cmd == 'purge':
         if options['cache_folder']:
             purge(folder=options['cache_folder'], gigs=options['size'])


### PR DESCRIPTION
I find this helpful for automation, to get the 'unpack' attribute for set in the manifest at add time so it's easy to propagate to the releng.manifest in-tree.