### PR TITLE
Run validate.sh from the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-check: python-tests shell-tests
+check: python-tests shell-tests validate
 
 shell-tests:
 	sh test.sh
@@ -11,4 +11,15 @@ python-test-%:
 	clear
 	python test_tooltool.py $*
 
-.PHONY: check shell-tests python-tests python-tests-%
+validate: _relengapi
+	source _relengapi/bin/activate && sh validate.sh
+
+PACKAGES = relengapi pep8 pyflakes coverage mock nose
+_relengapi:
+	virtualenv _relengapi
+	source _relengapi/bin/activate && pip install $(PACKAGES)
+
+clean:
+	-$(RM) -r _relengapi
+
+.PHONY: check clean shell-tests python-tests python-tests-% validate


### PR DESCRIPTION
I always forget about this test, only have travis complain
about missing coverage, etc. So run it from the default
make target.

As a pre-dependency, construct a python virtualenv under
_relengapi and install the testing dependencies there.

Add a 'make clean' target to remove the _relengapi virualenv.