### PR TITLE
Run validate.sh with tox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ matrix:
 install:
   - pip install -e .[test]
   - pip install coveralls
+  - pip install tox
   - pip freeze
 
-script: |
-    bash ./validate.sh
+script:
+  if $PY27; then tox -e py27; else tox -e py26; fi
 
 after_success:
   # only get coverage on python-2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
 
-# align the env's and the python's; below "$PY27 ||" will not be run on py26,
-# and "$PY27 &&" will only be run on py26.
+
+# Align the matrix with the corresponding TOXENV settings
+# to configure the correct variant for each tox invocation.
 matrix:
   include:
     - python: "2.6"
-      env: PY27=false
+      env: TOXENV=py26
     - python: "2.7"
-      env: PY27=true
+      env: TOXENV=py27
 
 
 install:
@@ -17,8 +18,8 @@ install:
   - pip freeze
 
 script:
-  if $PY27; then tox -e py27; else tox -e py26; fi
+  tox
 
 after_success:
   # only get coverage on python-2.7
-  - $PY27 && coveralls --rcfile coveragerc
+  - test $TOXENV = py27 && coveralls --rcfile coveragerc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-check: python-tests shell-tests
+check: python-tests shell-tests tox
 
 shell-tests:
 	sh test.sh
@@ -11,4 +11,7 @@ python-test-%:
 	clear
 	python test_tooltool.py $*
 
-.PHONY: check shell-tests python-tests python-tests-%
+tox:
+	tox
+
+.PHONY: check clean shell-tests python-tests python-tests-% tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Unified test environment.
+[tox]
+envlist = py26,py27
+[testenv]
+deps=
+  pep8
+  pyflakes
+  coverage
+  mock
+  nose
+commands=./validate.sh 


### PR DESCRIPTION
Example of setting up the test environment with tox instead, per @Callek in #26.

Two issues: travis tests verify with py26 as well, but that's hard for me. Fedora doesn't package it, and as far as I can tell, pip and tox can't install it. https://stackoverflow.com/questions/19858961/install-older-version-of-python-via-pip

I didn't update .travis.yml, but shoud.