### PR TITLE
don't add trailing whitepace when writing manifest entries

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -99,6 +99,8 @@ assert_zero $? "manifest file created"
 ###############
 $tt add a
 # TODO assert_nonzero $? "adding the same file a second time"
+egrep ' +$' manifest.tt
+assert_nonzero $? "lines must not end with spaces"
 ###############
 $tt add notafile
 #TODO this will always pass until the program is fixed

--- a/tooltool.py
+++ b/tooltool.py
@@ -306,7 +306,8 @@ class Manifest(object):
         assert fmt in self.valid_formats
         if fmt == 'json':
             rv = json.dump(
-                self.file_records, output_file, indent=0, cls=FileRecordJSONEncoder)
+                self.file_records, output_file, indent=0, cls=FileRecordJSONEncoder,
+                separators=(',', ': '))
             print >> output_file, ''
             return rv
 


### PR DESCRIPTION
The json module documentation notes that if |indent| is specified to
|json.dump|, trailing whitespace may be added to the output.  To prevent
this, it suggests specifying |separators| with no space after the item
separator.  Let's make this change to make manifest files a little
tidier, along with a test to ensure we don't regress.