### PR TITLE
Indent json when writing manifest files.

### DIFF
--- a/tooltool.py
+++ b/tooltool.py
@@ -306,7 +306,7 @@ class Manifest(object):
         assert fmt in self.valid_formats
         if fmt == 'json':
             rv = json.dump(
-                self.file_records, output_file, indent=0, cls=FileRecordJSONEncoder,
+                self.file_records, output_file, indent=2, cls=FileRecordJSONEncoder,
                 separators=(',', ': '))
             print >> output_file, ''
             return rv


### PR DESCRIPTION
Previously, tooltool manifests used no indenting (except when it
was added manually). Instead use a 2-space indent.

A code-oriented editor will maintain the intent scheme, so it's
no harder to update, but is much easier see the stanza boundaries
by eye.

The digest lines are already over 80 characters, so this doesn't
change the line-wrapping behaviour (145 vs 141 columns).