### PR TITLE
Add a --version switch for adding file version keys

### DIFF
--- a/test_tooltool.py
+++ b/test_tooltool.py
@@ -200,7 +200,7 @@ class TestFileRecord(BaseFileRecordTest):
         self.assertNotEqual(self.test_record, test_record2)
 
     def test_inequality(self):
-        for i in ['filename', 'size', 'algorithm', 'digest']:
+        for i in ['filename', 'size', 'algorithm', 'digest', 'version']:
             test_record2 = copy.deepcopy(self.test_record)
             test_record2.__dict__[i] = 'wrong!'
             self.assertNotEqual(self.test_record, test_record2)
@@ -316,6 +316,15 @@ class TestFileRecordJSONCodecs(BaseFileRecordListTest):
         from_json = json.loads(json_string,
                                cls=tooltool.FileRecordJSONDecoder)
         for i in ['filename', 'size', 'algorithm', 'digest', 'unpack', 'setup']:
+            self.assertEqual(getattr(from_json, i), getattr(self.test_record, i), i)
+
+    def test_json_dumps_with_version(self):
+        self.test_record.version = 'test 3.2.1 contact'
+        json_string = json.dumps(
+            self.test_record, cls=tooltool.FileRecordJSONEncoder)
+        from_json = json.loads(json_string,
+                               cls=tooltool.FileRecordJSONDecoder)
+        for i in ['filename', 'size', 'algorithm', 'digest', 'version']:
             self.assertEqual(getattr(from_json, i), getattr(self.test_record, i), i)
 
     def test_decode_list(self):
@@ -505,6 +514,13 @@ def test_command_add_unpack():
         eq_(call_main('tooltool', 'add', '--unpack', 'a', 'b'), 0)
         add_files.assert_called_with('manifest.tt', 'sha512', ['a', 'b'],
             None, None, True)
+
+def test_command_add_version():
+    with mock.patch('tooltool.add_files') as add_files:
+        version = 'foo 1.7.12-beta.2+test'
+        eq_(call_main('tooltool', 'add', '--version', version, 'foo.tar.gz'), 0)
+        add_files.assert_called_with('manifest.tt', 'sha512', ['foo.tar.gz'],
+                version, None, False)
 
 def test_command_add_visibility_internal():
     with mock.patch('tooltool.add_files') as add_files:

--- a/tooltool.py
+++ b/tooltool.py
@@ -80,7 +80,7 @@ class MissingFileException(ExceptionWithFilename):
 class FileRecord(object):
 
     def __init__(self, filename, size, digest, algorithm, unpack=False,
-                 visibility=None, setup=None):
+                 version=None, visibility=None, setup=None):
         object.__init__(self)
         if '/' in filename or '\\' in filename:
             log.error(
@@ -91,6 +91,7 @@ class FileRecord(object):
         self.digest = digest
         self.algorithm = algorithm
         self.unpack = unpack
+        self.version = version
         self.visibility = visibility
         self.setup = setup
 
@@ -101,6 +102,7 @@ class FileRecord(object):
            self.size == other.size and \
            self.digest == other.digest and \
            self.algorithm == other.algorithm and \
+           self.version == other.version and \
            self.visibility == other.visibility:
             return True
         else:
@@ -179,6 +181,8 @@ class FileRecordJSONEncoder(json.JSONEncoder):
             }
             if obj.unpack:
                 rv['unpack'] = True
+            if obj.version:
+                rv['version'] = obj.version
             if obj.visibility is not None:
                 rv['visibility'] = obj.visibility
             if obj.setup:
@@ -226,11 +230,12 @@ class FileRecordJSONDecoder(json.JSONDecoder):
 
             if not missing:
                 unpack = obj.get('unpack', False)
+                version = obj.get('version', None)
                 visibility = obj.get('visibility', None)
                 setup = obj.get('setup')
                 rv = FileRecord(
                     obj['filename'], obj['size'], obj['digest'], obj['algorithm'],
-                    unpack, visibility, setup)
+                    unpack, version, visibility, setup)
                 log.debug("materialized %s" % rv)
                 return rv
         return obj
@@ -398,7 +403,7 @@ def validate_manifest(manifest_file):
         return False
 
 
-def add_files(manifest_file, algorithm, filenames, visibility, unpack):
+def add_files(manifest_file, algorithm, filenames, version, visibility, unpack):
     # returns True if all files successfully added, False if not
     # and doesn't catch library Exceptions.  If any files are already
     # tracked in the manifest, return will be False because they weren't
@@ -415,6 +420,7 @@ def add_files(manifest_file, algorithm, filenames, visibility, unpack):
         log.debug("adding %s" % filename)
         path, name = os.path.split(filename)
         new_fr = create_file_record(filename, algorithm)
+        new_fr.version = version
         new_fr.visibility = visibility
         new_fr.unpack = unpack
         log.debug("appending a new file record to manifest file")
@@ -908,7 +914,8 @@ def process_command(options, args):
         return validate_manifest(options['manifest'])
     elif cmd == 'add':
         return add_files(options['manifest'], options['algorithm'], cmd_args,
-                         options['visibility'], options['unpack'])
+                         options['version'], options['visibility'],
+                         options['unpack'])
     elif cmd == 'purge':
         if options['cache_folder']:
             purge(folder=options['cache_folder'], gigs=options['size'])
@@ -961,6 +968,11 @@ def main(argv, _skip_logging=False):
                       dest='unpack', action='store_true',
                       help='Request unpacking this file after fetch.'
                            ' This is helpful with tarballs.')
+    parser.add_option('--version', default=None,
+                      dest='version', action='store',
+                      help='Version string for this file. This annotates the '
+                           'manifest entry with a version string to help '
+                           'identify the contents.')
     parser.add_option('-o', '--overwrite', default=False,
                       dest='overwrite', action='store_true',
                       help='UNUSED; present for backward compatibility')


### PR DESCRIPTION
Add a command-line switch for inserting the `version` keys we've been using to mark toolchain records in gecko manifests.