### PR TITLE
Bump version to 1.3.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ data_patterns = [
 ]
 
 setup(name='tooltool',
-      version='1.0.0',
+      version='1.3.0',
       description='Secure, cache-friendly access to large binary blobs for builds and tests',
       author='John Ford',
       author_email='jhford@mozilla.com',


### PR DESCRIPTION
This is vague semversioning based on new features which have
each been in use for a while. Imagining

- Adding setup scripts would be 1.1.0.
- Adding the 'unpack' key would be 1.2.0.
- Adding the 'version' key would be 1.3.0.